### PR TITLE
Adding more personas and role templates to improve clarity and handoffs

### DIFF
--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -75,7 +75,151 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
+## QA / Testing
+
+(Previously "QA/Testing" referenced in other docs—kept as the team's testing function.)
+
+### Role Summary
+QA/Testing validates quality and acceptance criteria; performs exploratory and manual testing when needed and verifies automated test coverage.
+
+### Responsibilities
+- Create and execute test plans for features
+- Maintain and improve automated test suites
+- Validate acceptance criteria and perform regression checks
+- Report and track quality-related risks and issues
+
+### Typical Communication
+- Release readiness checks with PM and Release Manager
+- Test reports and bug triage notes
+
+---
+
+## Stakeholders
+
+### Role Summary
+Stakeholders provide business context, input, and approvals. They include sponsor(s), business owners, and key partners.
+
+### Typical Communication
+- Monthly stakeholder updates
+- Decision meetings and sign-offs as needed
+
+---
+
+## New / Expanded Personas
+
+To close gaps and improve clarity we add the following personas. For each persona we provide role summary, responsibilities, and how they typically interact with existing roles.
+
+---
+
+### Scrum Master
+
+Role Summary
+- Facilitates the team's agile ceremonies, removes impediments, and helps the team follow agreed agile practices.
+
+Responsibilities
+- Facilitate sprint planning, daily standups, sprint reviews, and retrospectives
+- Help the team remove blockers and escalate impediments appropriately
+- Coach the delivery team and stakeholders on agile practices and team health
+- Track action items from retrospectives to closure
+
+Interactions
+- Works closely with Project Manager to align cadence and escalations
+- Supports Developers and QA by clearing operational obstacles
+- Partners with Product Manager on backlog readiness and sprint commitments
+
+---
+
+### Business Analyst (BA)
+
+Role Summary
+- Bridges product and delivery by clarifying requirements, documenting business rules, and validating acceptance criteria.
+
+Responsibilities
+- Elicit and document requirements and user stories
+- Maintain clear acceptance criteria and example scenarios
+- Coordinate stakeholder interviews and clarify edge cases
+- Support PdM and Developers during refinement and implementation
+
+Interactions
+- Works directly with Product Managers to detail priorities and acceptance criteria
+- Collaborates with Developers and QA to ensure requirements are testable and understood
+- Informs Project Managers of scope clarifications that affect timelines
+
+---
+
+### UX Designer
+
+Role Summary
+- Owns user experience design, research outputs, and usability validation to ensure the product is intuitive and usable.
+
+Responsibilities
+- Produce user flows, wireframes, prototypes, and design specs
+- Conduct usability testing and incorporate feedback
+- Provide design tokens, accessibility guidance, and handoff artifacts to Developers
+- Advocate for user needs during planning and prioritization
+
+Interactions
+- Partners with Product Managers early in discovery to shape requirements
+- Works with Developers and QA to ensure design intent is implemented and verified
+- Shares findings with Project Manager if design changes affect scope or schedule
+
+---
+
+### Release Manager
+
+Role Summary
+- Coordinates release planning, release execution, and rollback/mitigation plans to reduce deployment risk.
+
+Responsibilities
+- Create and maintain release timelines and checklists
+- Verify release readiness (CI, security, QA sign-offs, documentation)
+- Coordinate cross-team release activities and communicate windows
+- Maintain rollback plans and runbook references
+
+Interactions
+- Works with Project Managers and Product Managers to schedule releases
+- Coordinates with QA, Developers, and Support for release verification and post-release monitoring
+- Escalates release blockers to stakeholders when necessary
+
+---
+
+### Quality Lead
+
+Role Summary
+- Oversees quality strategy, test coverage, and acceptance standards across the program to ensure consistent quality outcomes.
+
+Responsibilities
+- Define test strategy and quality metrics for a program or product line
+- Review acceptance criteria and test coverage during planning
+- Mentor QA engineers and support automated testing initiatives
+- Track quality trends and feed back into planning and retrospectives
+
+Interactions
+- Works with Project Managers and Product Managers to set quality goals
+- Collaborates with Developers and QA teams to improve test automation and coverage
+- Supports Release Manager in gating criteria for releases
+
+---
+
+## Using these personas in OctoAcme processes
+
+- Add the primary role(s) for feature/epic in the Project One-pager and backlog items (owner fields).
+- Use the persona definitions during kickoffs to set expectations and escalation paths.
+- When assigning work, include the interaction points (e.g., "handoff to QA", "design review by UX, then dev implementation").
+- Capture role-specific artifacts: UX prototypes, BA acceptance docs, release checklists, and QA test reports.
+
+## Role Interaction Examples & Quick RACI (high-level)
+
+Example: Shipping a minor feature
+- Responsible: Developers, QA
+- Accountable: Product Manager
+- Consulted: UX Designer, Business Analyst
+- Informed: Project Manager, Stakeholders
+
+Use this document as the canonical reference for role definitions; maintain shorter, project-specific role assignments in the Project One-pager or backlog items.
+
+---
+
 ## How these personas are used in the exercise
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
-

--- a/docs/role-responsibilities-and-raci.md
+++ b/docs/role-responsibilities-and-raci.md
@@ -1,0 +1,71 @@
+# Role Responsibilities, Interaction Templates & RACI
+
+This file contains templates and checklists to make role responsibilities explicit, reduce ambiguity, and improve handoffs.
+
+---
+
+## 1) Role Responsibilities Template
+
+Use this template to document role responsibilities for a specific project or program.
+
+- Role:
+- Primary responsibilities (3–6 bullets):
+- Typical deliverables:
+- Key interactions (who they hand off to / who they consult):
+- RACI for major milestones:
+- Notes / Project-specific exceptions:
+
+Example (Release Manager)
+- Role: Release Manager
+- Primary responsibilities:
+  - Maintain release timeline and checklist
+  - Validate pre-release sign-offs (QA, security, docs)
+  - Coordinate deployment and post-release verification
+- Typical deliverables: Release checklist, rollback plan, release notes
+- Key interactions: PM (schedule), QA (readiness), Devs (deploy), Support (post-release)
+- RACI: Responsible: Release Manager; Accountable: PM; Consulted: QA, Devs; Informed: Stakeholders
+
+---
+
+## 2) RACI Matrix Template (simple table)
+
+Create a short RACI for a given milestone or deliverable. Columns are role names; rows are major activities.
+
+Activity | PM | PdM | Dev | QA | UX | BA | Release Manager
+--- | ---: | ---: | ---: | ---: | ---: | ---: | ---:
+Define success metrics | A | R | - | - | - | C | -
+Backlog refinement | C | R | C | C | C | C | -
+Development & unit testing | I | C | R | I | I | I | -
+Release validation & deploy | I | C | I | R | I | I | A
+
+Legend: R = Responsible, A = Accountable, C = Consulted, I = Informed
+
+---
+
+## 3) Role Handoff / Readiness Checklist (example)
+
+When moving work from one stage to another (e.g., Sprint → Release), use this checklist:
+
+- Backlog item has clear acceptance criteria (PdM, BA)
+- UX artifacts attached and accessible (UX)
+- Automated tests for new logic in place (Dev)
+- Manual QA test plan created (QA)
+- Performance/security scans passed (Dev, Sec)
+- Release checklist prepared (Release Manager)
+- Stakeholders informed of release window (PM)
+
+---
+
+## 4) How to use these templates
+
+- Add a filled Role Responsibilities Template to the Project One-pager for each named role.
+- Include a RACI snapshot for major milestones in planning docs.
+- Use the Handoff checklist as a required step in the release checklist (docs/release-and-deployment or project-specific release docs).
+
+---
+
+## 5) Acceptance criteria for adding/updating roles
+
+- Roles are named and responsibilities are actionable
+- Interaction points are documented and applied in project artifacts (one-pager, backlog)
+- Teams use the handoff and RACI templates during planning and releases


### PR DESCRIPTION
Summary:
Adds additional personas (Scrum Master, Business Analyst, UX Designer, Release Manager, Quality Lead) to docs/octoacme-roles-and-personas.md and introduces role responsibilities templates, a RACI template, and handoff/readiness checklists in docs/role-responsibilities-and-raci.md.
Motivation:
Addresses issue #4 — project docs currently focus on a small set of roles. As programs scale, missing role definitions and unclear handoffs cause ambiguity, slow decisions, and release friction. These changes clarify responsibilities, improve role interactions, and provide templates teams can adopt per-project.
Files changed:
docs/octoacme-roles-and-personas.md (expanded with new personas and interactions)
docs/role-responsibilities-and-raci.md (new templates and checklists)
Acceptance criteria (from the original issue):
Content aligns with existing process docs — yes: additions are consistent with the style and artifacts described across docs/
Update improves clarity or closes a documented gap — yes: adds role definitions and concrete templates for handoffs and RACI
Proposed content has been reviewed with stakeholders (if needed) — To be completed: request review from stakeholders (add reviewers)
Related issue(s):
Implements / references [#4 ](https://github.com/bethsi/skills-scale-institutional-knowledge-using-copilot-spaces/issues/4)